### PR TITLE
Fix behavior for wrapped buttons

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -2,6 +2,10 @@ import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import * as React from 'react';
 import {isTypeableElement} from '../utils/isTypeableElement';
 
+function isButtonTarget(event) {
+  return event.target && event.target.tagName === 'BUTTON';
+}
+
 export interface Props {
   enabled?: boolean;
   pointerDown?: boolean;
@@ -23,10 +27,6 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   }: Props = {}
 ): ElementProps => {
   const pointerTypeRef = React.useRef<'mouse' | 'pen' | 'touch'>();
-
-  function isButton() {
-    return refs.domReference.current?.tagName === 'BUTTON';
-  }
 
   function isSpaceIgnored() {
     return isTypeableElement(refs.domReference.current);
@@ -99,7 +99,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
       onKeyDown(event) {
         pointerTypeRef.current = undefined;
 
-        if (isButton()) {
+        if (isButtonTarget(event)) {
           return;
         }
 
@@ -119,7 +119,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
         }
       },
       onKeyUp(event) {
-        if (isButton() || isSpaceIgnored()) {
+        if (isButtonTarget(event) || isSpaceIgnored()) {
           return;
         }
 


### PR DESCRIPTION
The current implementation of `useClick` tries to bail on keyDown/Up handlers on button targets to avoid redundant handling of float state because pressing ENTER/SPACE on buttons trigger a click event. Checking if the reference element is a button causes it to incorrectly bail on the wrong element type when the actual event is triggered by a different element than the reference. 

One possible solution is to check if the target that triggered the event is a button instead - that is regardless of the type of the wrapping reference.

[Here](https://codesandbox.io/s/serene-noether-bqk39m?file=/src/App.tsx)'s a reproduction of the issue.